### PR TITLE
fix: Link to Pokemon Realistic Cards project

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -204,7 +204,7 @@
 
     <section class="intro" id="⚓-intro">
       <p>
-        A re-build of my <a href="https://poke-151.simey.me"
+        A re-build of my <a href="https://poke-holo.simey.me/"
           >Pokemon Realistic Cards project</a
         >, but for the legendary Pokemon 151 set (sv3.6);
       </p>


### PR DESCRIPTION
The link to the https://poke-holo.simey.me/ project was pointing to the 151 app itself instead of the correct URL.